### PR TITLE
Resolve b:match_words undefined

### DIFF
--- a/ftplugin/delphi.vim
+++ b/ftplugin/delphi.vim
@@ -62,7 +62,8 @@ if exists("loaded_matchit")
   let s:after_impl = '\('.s:sl.'implementation\)\@<='
   let s:proc_or_func_words = '\<\%(constructor\|destructor\|procedure\|function\)\>'
   let s:end_word         = '\<end\>'
-
+  
+  let b:match_words            = ''
   let b:delphi_match_words     = ''
   "it doesn't work in interface
   "let b:delphi_match_words     .= s:after_impl.s:nc.s:proc_or_func_words.':'.s:nc.'\<begin\>:'.s:nc.s:end_word


### PR DESCRIPTION
Required the predefined variable before any additions

https://github.com/mattia72/vim-delphi/blob/master/ftplugin/delphi.vim#L85
